### PR TITLE
tiny layout refinement for small screens

### DIFF
--- a/css/qrid.scss
+++ b/css/qrid.scss
@@ -45,6 +45,9 @@ $one: 500px;
   .grid {
     --repeat: 1;
   }
+  .grid[data-style="buttons"] {
+    margin-bottom: -10px;
+  }
 }
 
 .grid[data-style="square"] {


### PR DESCRIPTION
Before:
--1--
<img width="498" alt="Screenshot 2025-04-02 at 11 54 11 AM" src="https://github.com/user-attachments/assets/453cc08e-f368-469d-88f0-13c4c1f79985" />
--2--
<img width="571" alt="Screenshot 2025-04-02 at 11 54 20 AM" src="https://github.com/user-attachments/assets/1b9533b8-d475-4b23-b04a-9095b1e26541" />

After:
--1--
<img width="571" alt="Screenshot 2025-04-02 at 11 54 30 AM" src="https://github.com/user-attachments/assets/66d54324-8f24-4588-b6c4-bfdcf0e0a041" />
--2--
<img width="571" alt="Screenshot 2025-04-02 at 11 54 37 AM" src="https://github.com/user-attachments/assets/e5310d4e-00f0-4784-8888-75f51faed41a" />
